### PR TITLE
CLI cleanup, report improvements, README rewrite

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
-          package-name: copilot-arewecooked
+          target-branch: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2026-04-29)
+
+
+### Features
+
+* initial Copilot billing estimator ([6f78718](https://github.com/PanAchy/copilot-arewecooked/commit/6f787182a1ff07d8a00900dc197a09946066da0e))

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PanAchy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,85 +1,89 @@
-# GitHub Copilot, are we cooked?
+<div align="center">
 
-_Are your Copilot AI credits cooked?_
+# Yo GitHub Copilot: are we cooked?
+
+</div>
 
 Estimate your GitHub Copilot AI-credit cost in preparation for June 1st.
-This will allow you to pull usage out of:
+Pulls usage from VS Code, OpenCode, Pi, and GitHub Copilot CLI, aggregates
+it based on the new per-token pricing, and tells you if you're over or under.
 
-- VS Code
-- OpenCode
-- Pi
-- GitHub Copilot CLI
-
-and aggregate it based on the new costs, to help you know if you are over or under.
-
-#### Relevant information
+#### Relevant links
 
 - [April 27th, 2026: GitHub Copilot is moving to usage-based billing](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/)
 - [Models and per-token pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing#model-multipliers-for-annual-copilot-pro-and-copilot-pro-subscribers)
 - [Usage-based billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals)
 - [Usage-based billing for organizations and enterprises](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises)
 
-_TL;DR The premium request system allowed users with the right set of orchestration (e.g. subagents) to become very efficient at using their GitHub Copilot subscription. These orchestration techniques stop mattering because billing is moving to input/output/cache token based pricing._
+> TL;DR: GitHub Copilot is moving from premium-request quotas to per-token billing on June 1st. Orchestration tricks such as the use of subagents no longer saves you usage on this plan.
 
-## Run
+## Setup
+
+[Download the latest release](../../releases) and unzip, then:
 
 ```bash
 npm install
 npm run build
-node dist/cli.js
+npm start
 ```
 
-Options:
+### Options
+
+| Flag     | Description                      |
+| -------- | -------------------------------- |
+| `--days` | Days to look back (default: all) |
+| `--json` | Print normalized JSON            |
 
 ```bash
-node dist/cli.js --days 30
-node dist/cli.js --json
-node dist/cli.js --no-vscode
-node dist/cli.js --no-opencode
-node dist/cli.js --no-pi
-node dist/cli.js --no-copilot-cli
+npm start -- --days 30
+npm start -- --json
+```
+
+### Example output
+
+```bash
+npm start
+Period: all available data
+
+Sources
+Tool         Calls  Tokens  Credits
+-----------  -----  ------  -------
+OpenCode         7  70,494     1.13
+Pi               2   9,308    0.254
+Copilot CLI      6  60,433    2.297
+VS Code          3   3,354    0.031
+
+Tokens
+Type         Tokens
+-----------  ------
+Input        65,798
+Output       11,743
+Cache read   66,048
+Cache write       0
+
+Estimated cost: 3.712 AI credits | $0.0371
+
+Plan         Included  Remaining       %
+----------  ---------  ---------  ------
+pro            1,000      996.3   99.6%
+pro+           3,900    3,896.3   99.9%
+business       1,900    1,896.3   99.8%
+enterprise     3,900    3,896.3   99.9%
 ```
 
 ## How data is extracted
 
-### VS Code Copilot
+| Source          | Paths                                                                                                                                                                                                                                       | Token accuracy                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| **VS Code**     | `~/Library/Application Support/Code/User/workspaceStorage/*/chatSessions/*.jsonl` (macOS) · `%APPDATA%/Code/User/workspaceStorage/*/chatSessions/*.jsonl` (Windows) · `~/.config/Code/User/workspaceStorage/*/chatSessions/*.jsonl` (Linux) | Input estimated, output exact, cache not persisted |
+| **OpenCode**    | `~/.local/share/opencode/opencode.db` (macOS and Linux)`%LOCALAPPDATA%/opencode/opencode.db` / `%APPDATA%/opencode/opencode.db` (Windows)                                                                                                   | All exact (input, output, cache read/write)        |
+| **Pi**          | `~/.pi/agent/sessions/**/*.jsonl` (all platforms)                                                                                                                                                                                           | All exact (input, output, cache read/write)        |
+| **Copilot CLI** | `~/.copilot/session-state/*/events.jsonl` (all platforms)                                                                                                                                                                                   | Output exact, input estimated, compaction exact    |
 
-Paths checked:
+## Contributing
 
-`~/Library/Application Support/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
+PRs welcome. Run `npm run check` to build and verify.
 
-`%APPDATA%/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
+## License
 
-`~/.config/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
-
-Uses patch-reduced chat session requests; exact `completionTokens`; input estimated from rendered context; cache tokens not persisted.
-
-### OpenCode
-
-Paths checked:
-
-`~/.local/share/opencode/opencode.db`
-
-`~/Library/Application Support/opencode/opencode.db`
-
-`%LOCALAPPDATA%/opencode/opencode.db`
-
-`%APPDATA%/opencode/opencode.db`
-
-Uses `message.data` assistant rows where `providerID === "github-copilot"`; exact `tokens.input`, `tokens.output`, `tokens.cache.read/write`; tool counts from `part.data` for `question`, `task`, `delegate_task`.
-
-### Pi
-
-Paths checked:
-
-`~/.pi/agent/sessions/**/*.jsonl`
-
-Uses assistant messages where `provider === "github-copilot"`; exact `usage.input`, `usage.output`, `usage.cacheRead/cacheWrite`.
-
-### GitHub Copilot CLI
-
-Paths checked:
-
-`~/.copilot/session-state/*/events.jsonl`
-
-Uses normal assistant messages for exact `outputTokens`; input is estimated from local event content; compaction events expose exact `compactionTokensUsed`.
+[MIT](./LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-arewecooked",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-arewecooked",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-arewecooked",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Local GitHub Copilot AI-credit billing estimator for OpenCode and Pi usage logs.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,6 @@
 import { Command } from "commander";
 import { existsSync } from "node:fs";
 import { buildSummary, costRecords, renderConsole } from "./report.js";
-import type { SourceAdapter } from "./source.js";
 import { sourceAdapters } from "./sources.js";
 
 const program = new Command();
@@ -12,79 +11,37 @@ program
   .description(
     "Local GitHub Copilot AI-credit billing estimator for local usage logs."
   )
-  .option("--days <days>", "days to look back", "30")
-  .option("--opencode-db <path>", "OpenCode sqlite database path")
-  .option("--pi-sessions <path>", "Pi sessions directory")
-  .option(
-    "--copilot-cli-state <path>",
-    "GitHub Copilot CLI session-state directory"
-  )
-  .option("--vscode-storage <path>", "VS Code workspaceStorage directory")
-  .option("--no-opencode", "skip OpenCode")
-  .option("--no-pi", "skip Pi")
-  .option("--no-copilot-cli", "skip GitHub Copilot CLI")
-  .option("--no-vscode", "skip VS Code Copilot")
+  .option("--days <days>", "days to look back")
   .option("--json", "print normalized JSON")
   .parse(process.argv);
 
 const options = program.opts<{
-  days: string;
-  opencodeDb?: string;
-  piSessions?: string;
-  copilotCliState?: string;
-  vscodeStorage?: string;
-  opencode: boolean;
-  pi: boolean;
-  copilotCli: boolean;
-  vscode: boolean;
+  days?: string;
   json?: boolean;
 }>();
 
-const periodDays = Number.parseInt(options.days, 10);
-if (!Number.isFinite(periodDays) || periodDays <= 0) {
-  console.error("--days must be a positive integer");
-  process.exit(1);
+let periodDays: number | undefined;
+let sinceMs: number | undefined;
+
+if (options.days) {
+  periodDays = Number.parseInt(options.days, 10);
+  if (!Number.isFinite(periodDays) || periodDays <= 0) {
+    console.error("--days must be a positive integer");
+    process.exit(1);
+  }
+  sinceMs = Date.now() - periodDays * 24 * 60 * 60 * 1000;
 }
 
-function selectedPaths(adapter: SourceAdapter, override?: string): string[] {
-  if (override) return [override];
-  const paths = adapter.defaultPaths();
-  const existing = paths.filter((path) => existsSync(path));
-  return existing.length > 0 ? existing : [paths[0]];
-}
-
-const sinceMs = Date.now() - periodDays * 24 * 60 * 60 * 1000;
 const findings = [];
 const records = [];
 const toolFindings = [];
 
-const enabledSources: Array<{
-  enabled: boolean;
-  adapter: SourceAdapter;
-  path?: string;
-}> = [
-  {
-    enabled: options.vscode,
-    adapter: sourceAdapters.vscode,
-    path: options.vscodeStorage,
-  },
-  {
-    enabled: options.opencode,
-    adapter: sourceAdapters.opencode,
-    path: options.opencodeDb,
-  },
-  { enabled: options.pi, adapter: sourceAdapters.pi, path: options.piSessions },
-  {
-    enabled: options.copilotCli,
-    adapter: sourceAdapters.copilotCli,
-    path: options.copilotCliState,
-  },
-];
-
-for (const source of enabledSources) {
-  if (!source.enabled) continue;
-  for (const path of selectedPaths(source.adapter, source.path)) {
-    const result = source.adapter.parse(path, sinceMs);
+for (const adapter of Object.values(sourceAdapters)) {
+  const paths = adapter.defaultPaths();
+  const existing = paths.filter((p) => existsSync(p));
+  const toCheck = existing.length > 0 ? existing : [paths[0]];
+  for (const path of toCheck) {
+    const result = adapter.parse(path, sinceMs);
     findings.push(result.finding);
     records.push(...result.records);
     toolFindings.push(...(result.toolFindings ?? []));

--- a/src/copilotCli.ts
+++ b/src/copilotCli.ts
@@ -2,6 +2,7 @@ import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { copilotCliStatePaths } from "./paths.js";
 import type { SourceFinding, UsageRecord } from "./types.js";
+import type { SourceParseResult } from "./source.js";
 
 export function defaultCopilotCliStatePaths(): string[] {
   return copilotCliStatePaths();
@@ -15,7 +16,7 @@ function roughTokens(value: unknown): number {
 export function parseCopilotCli(
   basePath = defaultCopilotCliStatePaths()[0],
   sinceMs?: number
-): { finding: SourceFinding; records: UsageRecord[] } {
+): SourceParseResult {
   const finding: SourceFinding = {
     source: "copilot-cli",
     path: basePath,

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import { existsSync } from "node:fs";
 import { opencodeDbPaths } from "./paths.js";
 import type { SourceFinding, ToolFinding, UsageRecord } from "./types.js";
+import type { SourceParseResult } from "./source.js";
 
 export function defaultOpenCodeDbPaths(): string[] {
   return opencodeDbPaths();
@@ -17,11 +18,7 @@ function isCopilotProvider(provider?: string, model?: string): boolean {
 export function parseOpenCode(
   path = defaultOpenCodeDbPaths()[0],
   sinceMs?: number
-): {
-  finding: SourceFinding;
-  records: UsageRecord[];
-  toolFindings: ToolFinding[];
-} {
+): SourceParseResult {
   const finding: SourceFinding = {
     source: "opencode",
     path,

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -2,6 +2,7 @@ import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { piSessionsPaths } from "./paths.js";
 import type { SourceFinding, UsageRecord } from "./types.js";
+import type { SourceParseResult } from "./source.js";
 
 export function defaultPiSessionsPaths(): string[] {
   return piSessionsPaths();
@@ -10,7 +11,7 @@ export function defaultPiSessionsPaths(): string[] {
 export function parsePi(
   basePath = defaultPiSessionsPaths()[0],
   sinceMs?: number
-): { finding: SourceFinding; records: UsageRecord[] } {
+): SourceParseResult {
   const finding: SourceFinding = {
     source: "pi",
     path: basePath,

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,8 +7,15 @@ import type {
 import { comparePlans, costRecord } from "./pricing.js";
 import { renderTable } from "./table.js";
 
+const DISPLAY_NAMES: Record<string, string> = {
+  vscode: "VS Code",
+  opencode: "OpenCode",
+  pi: "Pi",
+  "copilot-cli": "Copilot CLI",
+};
+
 export function buildSummary(args: {
-  periodDays: number;
+  periodDays?: number;
   findings: SourceFinding[];
   records: CostedUsageRecord[];
   toolFindings: ToolFinding[];
@@ -125,14 +132,18 @@ function sourceRows(summary: Summary) {
 export function renderConsole(summary: Summary): string {
   const lines: string[] = [];
   lines.push("copilot-arewecooked");
-  lines.push(`Period: last ${summary.periodDays}d`);
+  lines.push(
+    summary.periodDays
+      ? `Period: last ${summary.periodDays}d`
+      : "Period: all available data"
+  );
   lines.push("");
   lines.push("Sources");
   const sources = sourceRows(summary);
   if (sources.length > 0) {
     lines.push(
       ...renderTable(sources, [
-        { header: "Tool", value: (row) => row.tool },
+        { header: "Tool", value: (row) => DISPLAY_NAMES[row.tool] ?? row.tool },
         { header: "Calls", value: (row) => fmt(row.calls, 0), align: "right" },
         {
           header: "Tokens",
@@ -167,32 +178,42 @@ export function renderConsole(summary: Summary): string {
     )
   );
 
-  lines.push("");
   lines.push(
-    `Estimated June billing: ${fmtCredits(summary.totals.credits)} AI credits ($${fmt(summary.totals.usd, 4)})`
+    `Estimated cost: ${fmtCredits(summary.totals.credits)} AI credits | $${fmt(summary.totals.usd, 4)}`
   );
   lines.push("");
-  lines.push("Plan fit");
+  const relevantPlans = summary.plans.filter((plan) =>
+    ["pro", "pro+", "business", "enterprise"].includes(plan.plan)
+  );
   lines.push(
-    ...renderTable(
-      summary.plans.filter((plan) =>
-        ["pro", "pro+", "business", "enterprise"].includes(plan.plan)
-      ),
-      [
-        { header: "Plan", value: (row) => row.plan },
-        {
-          header: "Used",
-          value: (row) => fmtCredits(row.usedCredits),
-          align: "right",
+    ...renderTable(relevantPlans, [
+      { header: "Plan", value: (row) => row.plan },
+      {
+        header: "Included",
+        value: (row) => fmt(row.includedCredits, 0),
+        align: "right",
+      },
+      {
+        header: "Remaining",
+        value: (row) => {
+          const remaining = row.includedCredits - row.usedCredits;
+          return remaining < 0
+            ? fmtCredits(Math.abs(remaining))
+            : fmtCredits(remaining);
         },
-        {
-          header: "Included",
-          value: (row) => fmt(row.includedCredits, 0),
-          align: "right",
+        align: "right",
+      },
+      {
+        header: "%",
+        value: (row) => {
+          const pct =
+            ((row.includedCredits - row.usedCredits) / row.includedCredits) *
+            100;
+          return `${pct < 0 ? "-" : ""}${fmt(Math.abs(pct), 1)}%`;
         },
-        { header: "Verdict", value: (row) => row.verdict },
-      ]
-    )
+        align: "right",
+      },
+    ])
   );
   return lines.join("\n");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface PlanComparison {
 
 export interface Summary {
   generatedAt: string;
-  periodDays: number;
+  periodDays?: number;
   sources: SourceFinding[];
   records: CostedUsageRecord[];
   toolFindings: ToolFinding[];

--- a/src/vscode.ts
+++ b/src/vscode.ts
@@ -2,6 +2,7 @@ import fg from "fast-glob";
 import { existsSync, readFileSync } from "node:fs";
 import { vscodeStoragePaths } from "./paths.js";
 import type { SourceFinding, UsageRecord } from "./types.js";
+import type { SourceParseResult } from "./source.js";
 
 export function defaultVsCodeWorkspaceStoragePaths(): string[] {
   return vscodeStoragePaths();
@@ -57,7 +58,7 @@ function reconstructSession(file: string): any {
 export function parseVsCode(
   basePath = defaultVsCodeWorkspaceStoragePaths()[0],
   sinceMs?: number
-): { finding: SourceFinding; records: UsageRecord[] } {
+): SourceParseResult {
   const finding: SourceFinding = {
     source: "vscode",
     path: basePath,


### PR DESCRIPTION
Simplifies CLI to `--days`/`--json` only, improves report display (plan fit table, source names, cost line), rewrites README with clearer setup instructions and extraction table, adds MIT license.