### PR TITLE
chore(release): use plain version tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ fixtures/local/
 
 # Package artifacts
 *.tgz
+
+AGENTS.md

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,5 +6,6 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }
-  }
+  },
+  "include-component-in-tag": false
 }


### PR DESCRIPTION
Configure release-please to create plain v0.x.y tags instead of component-prefixed tags. Also ignores local AGENTS.md.