### PR TITLE
docs(skill): target feature PRs at develop

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -7,12 +7,12 @@ description: Create PRs with titles and bodies that produce accurate release not
 
 ## Rules
 
-1. Create short-lived feature branches from `main` for all work.
-2. Open PRs from feature branches directly into `main`.
-3. Prefer squash merge. The PR title becomes the single Conventional Commit that release-please reads.
-4. The PR title becomes the release-please changelog entry. The PR body becomes the GitHub Release notes.
-5. Write the title as a single conventional commit summarizing actual diff changes.
-6. Enumerate every meaningful actual diff change in the body.
+1. Create short-lived feature branches from `develop` for all work.
+2. Open normal work PRs from feature branches into `develop`.
+3. Prefer squash merge for feature → develop PRs. The PR title becomes one clean Conventional Commit on `develop`.
+4. Open release PRs from `develop` into `main` when ready to ship.
+5. Merge release PRs with a merge commit, not squash, so release-please sees the individual Conventional Commits accumulated on `develop`.
+6. The release PR body becomes useful release context, but release-please changelog entries come from commits merged to `main`.
 7. Use `fix(...)` for release-affecting fixes, including broken publish/release automation. Do not use `ci(...)` if the change must trigger a release.
 
 ## PR title format
@@ -41,17 +41,26 @@ Pick the highest-impact type: `feat` > `fix` > `refactor` > `test` > `docs` > `c
 - [ ] <how to verify>
 ```
 
-## Before creating the PR
+## Before creating a feature → develop PR
 
 1. Run `git fetch origin`.
 2. Confirm current branch is a feature branch, not `main` or `develop`: `git branch --show-current`.
-3. Run `git diff origin/main...HEAD --name-status` to see actual changed files in the PR.
-4. Run `git diff origin/main...HEAD -- <file>` to understand actual content changes.
+3. Run `git diff origin/develop...HEAD --name-status` to see actual changed files in the PR.
+4. Run `git diff origin/develop...HEAD -- <file>` to understand actual content changes.
 5. Synthesize the title and body from the diff, not from commit headlines alone.
 6. Verify `npm run build && npm test` passes.
 7. Push the branch: `git push -u origin <branch>`.
-8. Create PR: `gh pr create --base main --head <branch> --title "<title>" --body "<body>"`.
+8. Create PR: `gh pr create --base develop --head <branch> --title "<title>" --body "<body>"`.
 9. After creating PR, run `gh pr diff <number> --name-only` and `gh pr view <number> --json files,title,body` to confirm body matches actual changed files.
+
+## Before creating a develop → main release PR
+
+1. Run `git fetch origin`.
+2. Run `git diff origin/main...origin/develop --name-status` to see actual release contents.
+3. Run `git log --oneline origin/main..origin/develop` to review Conventional Commits that release-please will see after merge.
+4. Verify release PR body summarizes the diff, not stale branch history.
+5. Create PR: `gh pr create --base main --head develop --title "chore(release): merge develop into main" --body "<body>"`.
+6. Merge with a merge commit, not squash.
 
 ## Title quality check
 


### PR DESCRIPTION
## What changed

- Update the create-pr skill so feature branches are created from develop and PR into develop.
- Document squash merge for feature → develop PRs so develop accumulates clean Conventional Commits.
- Document develop → main release PRs as merge commits, not squash, so release-please sees individual commits.
- Add separate checklist for feature PRs and release PRs.

## Context

This matches the intended integration workflow: stack work on develop, then merge develop to main when ready to release.

## Test plan

- [x] npm test