### PR TITLE
fix: use execSync in build script to fix Windows builds

### DIFF
--- a/scripts/build-report-css.mjs
+++ b/scripts/build-report-css.mjs
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,9 +6,8 @@ import { join } from "node:path";
 const tmp = mkdtempSync(join(tmpdir(), "copilot-report-css-"));
 const out = join(tmp, "report.css");
 try {
-  execFileSync(
-    "npx",
-    ["tailwindcss", "-i", "src/report.css", "-o", out, "--minify"],
+  execSync(
+    `npx tailwindcss -i src/report.css -o "${out}" --minify`,
     { stdio: "inherit" }
   );
   const css = readFileSync(out, "utf8");


### PR DESCRIPTION
## Problem

`npm run build` fails on Windows with:

```
Error: spawnSync npx ENOENT
```

This happens because `execFileSync('npx', ...)` cannot resolve `.cmd` extensions on Windows without a shell context. Node.js requires either `shell: true` or the explicit `.cmd` extension, and the latter also fails (EINVAL) on Node.js v24.

## Fix

Switch from `execFileSync` to `execSync` with a command string. `execSync` uses the system shell which resolves `npx` correctly on all platforms. The arguments are all hardcoded constants so there is no shell injection concern.