### PR TITLE
fix: prototype pollution in setPath, sinceMs timestamp filter, chart bucketing, and mock findings

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -88,13 +88,16 @@ function bucketTrend(records: CostedUsageRecord[]): TrendPoint[] {
   const first = dated[0]!.ts;
   const last = dated[dated.length - 1]!.ts;
   const dayMs = 24 * 60 * 60 * 1000;
-  const spanDays = Math.max(1, Math.ceil((last - first) / dayMs) + 1);
+  const firstMidnight = new Date(first);
+  firstMidnight.setHours(0, 0, 0, 0);
+  const firstMs = firstMidnight.getTime();
+  const spanDays = Math.max(1, Math.ceil((last - firstMs) / dayMs) + 1);
   const bucketDays = spanDays > 90 ? 7 : 1;
   const map = new Map<number, number>();
 
   for (const record of dated) {
-    const index = Math.floor((record.ts - first) / dayMs / bucketDays);
-    const bucketStart = first + index * bucketDays * dayMs;
+    const index = Math.floor((record.ts - firstMs) / dayMs / bucketDays);
+    const bucketStart = firstMs + index * bucketDays * dayMs;
     map.set(bucketStart, (map.get(bucketStart) ?? 0) + record.credits);
   }
 

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -118,6 +118,13 @@ const summary = buildSummary({
       records: records.filter((r) => r.source === "vscode").length,
       notes: [],
     },
+    {
+      source: "vscode-insiders",
+      path: "/mock/vscode-insiders",
+      found: true,
+      records: records.filter((r) => r.source === "vscode-insiders").length,
+      notes: [],
+    },
   ],
   records: costed,
   toolFindings: [],

--- a/src/vscode.ts
+++ b/src/vscode.ts
@@ -27,6 +27,8 @@ function modelFromRequest(request: any): string {
   return modelId;
 }
 
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 function setPath(
   target: any,
   path: Array<string | number>,
@@ -35,16 +37,19 @@ function setPath(
   let cursor = target;
   for (let index = 0; index < path.length - 1; index++) {
     const key = path[index];
+    if (typeof key === "string" && UNSAFE_KEYS.has(key)) return;
     const nextKey = path[index + 1];
     if (cursor[key] == null)
       cursor[key] = typeof nextKey === "number" ? [] : {};
     cursor = cursor[key];
   }
-  cursor[path[path.length - 1]] = value;
+  const lastKey = path[path.length - 1];
+  if (typeof lastKey === "string" && UNSAFE_KEYS.has(lastKey)) return;
+  cursor[lastKey] = value;
 }
 
 function reconstructSession(file: string): any {
-  const state: any = {};
+  const state: any = Object.create(null);
   for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
     if (!line.trim()) continue;
     let event: any;
@@ -64,7 +69,7 @@ function collectSessionRequests(file: string): {
   session: any;
   requests: any[];
 } {
-  const state: any = {};
+  const state: any = Object.create(null);
   const requestsById = new Map<string, any>();
 
   const captureRequest = (request: any) => {
@@ -167,7 +172,13 @@ function parseVsCodeVariant(
 
     for (const request of sessionRequests) {
       if (!request) continue;
-      if (sinceMs && request.timestamp && request.timestamp < sinceMs) continue;
+      if (sinceMs && request.timestamp) {
+        const ts =
+          typeof request.timestamp === "string"
+            ? Date.parse(request.timestamp)
+            : Number(request.timestamp);
+        if (Number.isFinite(ts) && ts < sinceMs) continue;
+      }
       const metadata = request.result?.metadata ?? {};
       const inputEstimate =
         roughTokens(metadata.renderedUserMessage) +


### PR DESCRIPTION
## What changed

- **`src/vscode.ts`** — Guard `setPath` against prototype-polluting keys (`__proto__`, `constructor`, `prototype`); use `Object.create(null)` for state in both `reconstructSession` and `collectSessionRequests` to prevent prototype chain traversal
- **`src/vscode.ts`** — Normalize `request.timestamp` before `sinceMs` comparison: ISO string timestamps now convert via `Date.parse` instead of being compared as strings against a number (which coerces to `NaN` and bypasses the filter)
- **`src/html.ts`** — Anchor trend chart buckets to midnight of the first record's day instead of the first record's exact timestamp, so records on the same calendar date always land in the same bucket
- **`src/mock.ts`** — Add missing `vscode-insiders` finding entry to `buildSummary` call so the mock report is internally consistent with the records it generates

## Context

Security and data integrity bugs surfaced during adversarial review of PR #22 (feat: VS Code Insiders support). The prototype pollution is a Critical fix — a crafted `.jsonl` file in `workspaceStorage` could mutate `Object.prototype` for the entire Node process. The remaining fixes correct silent data integrity issues in timestamp filtering and chart rendering.

## Test plan

- [ ] Run `npm run typecheck` — passes
- [ ] Run `npx tsx src/mock.ts --html report.html` and verify VS Code Insiders appears as a source in the report with a non-zero finding count
- [ ] Verify trend chart shows correct calendar dates (each day as a separate bucket)
- [ ] Verify that records older than a given cutoff are excluded when `sinceMs` is passed programmatically (internal API — no CLI flag in this PR)