### PR TITLE
chore: remove bump-patch-for-minor-pre-major so feat: triggers minor version bumps

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,8 +3,7 @@
     ".": {
       "release-type": "node",
       "initial-version": "0.2.0",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   },
   "include-component-in-tag": false


### PR DESCRIPTION
## What changed

- Removed `bump-patch-for-minor-pre-major: true` from `.release-please-config.json`

## Context

With that option set, Release Please treated `feat:` commits as patch bumps while the major version is `0`. Removing it restores standard semver behaviour: `feat:` → minor bump, `fix:` → patch bump.

## Test plan

- [ ] Merge to develop → main
- [ ] Next `feat:` PR should produce e.g. `0.4.0 → 0.5.0` not `0.4.0 → 0.4.1`