### PR TITLE
fix(publish): auto-trigger on tag push and restore minor version bumps for feat commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: publish
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -21,12 +22,17 @@ jobs:
       contents: read
       id-token: write
     concurrency:
-      group: publish-${{ github.event.release.tag_name || inputs.tag }}
+      group: publish-${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.tag }}
       cancel-in-progress: false
     steps:
       - name: Resolve release tag
         id: release
-        run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,8 +3,7 @@
     ".": {
       "release-type": "node",
       "initial-version": "0.2.0",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   },
   "include-component-in-tag": false


### PR DESCRIPTION
## What changed

- **fix(publish)**: `publish.yml` now triggers on `push: tags: v*` instead of `release: published` — Release Please creates releases via `GITHUB_TOKEN` which does not fire downstream workflow events; tag pushes do (#31)
- **chore**: Removed `bump-patch-for-minor-pre-major` from `.release-please-config.json` so `feat:` commits produce minor version bumps instead of patch (#32)

## Context

`v0.3.4` was never published to npm because the publish workflow silently didn't fire. Root cause: GitHub blocks `GITHUB_TOKEN`-created events from triggering other workflows. Switching to tag push trigger fixes this permanently.

## Test plan

- [ ] Merge this PR
- [ ] Release Please opens a release PR automatically
- [ ] Merge the release PR — a new `v*` tag is pushed
- [ ] Confirm `publish` workflow fires and `npm view copilot-arewecooked version` shows the new version