### PR TITLE
Use streaming to handle large files

### DIFF
--- a/src/copilotCli.ts
+++ b/src/copilotCli.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { copilotCliStatePaths } from "./paths.js";
 import type { SourceFinding, UsageRecord } from "./types.js";
 import type { SourceParseResult } from "./source.js";
-import { roughTokens } from "./utils.js";
+import { roughTokens, readLinesFromFile } from "./utils.js";
 
 export function defaultCopilotCliStatePaths(): string[] {
   return copilotCliStatePaths();
@@ -33,7 +33,7 @@ export function parseCopilotCli(
     let currentModel = "gpt-5-mini";
     let pendingInputEstimate = 0;
 
-    for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+    for (const line of readLinesFromFile(file)) {
       if (!line.trim()) continue;
       let event: any;
       try {

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { piSessionsPaths } from "./paths.js";
 import type { SourceFinding, UsageRecord } from "./types.js";
 import type { SourceParseResult } from "./source.js";
+import { readLinesFromFile } from "./utils.js";
 
 export function defaultPiSessionsPaths(): string[] {
   return piSessionsPaths();
@@ -29,7 +30,7 @@ export function parsePi(
   });
   for (const file of files) {
     let sessionId: string | undefined;
-    for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+    for (const line of readLinesFromFile(file)) {
       if (!line.trim()) continue;
       let data: any;
       try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { openSync, readSync, closeSync } from "node:fs";
+
 export function roughTokens(value: unknown): number {
   if (value == null) return 0;
   return Math.ceil(JSON.stringify(value).length / 4);
@@ -10,3 +12,22 @@ export const DISPLAY_NAMES: Record<string, string> = {
   pi: "Pi",
   "copilot-cli": "Copilot CLI",
 };
+
+export function* readLinesFromFile(filePath: string): Generator<string> {
+  const fd = openSync(filePath, 'r');
+  const buffer = Buffer.alloc(1024 * 1024); // 1MB chunks
+  let leftover = '';
+  let bytesRead: number;
+  while ((bytesRead = readSync(fd, buffer, 0, buffer.length, null)) > 0) {
+    const chunk = leftover + buffer.toString('utf8', 0, bytesRead);
+    const lines = chunk.split(/\r?\n/);
+    leftover = lines.pop() || ''; // last part might be incomplete
+    for (const line of lines) {
+      yield line;
+    }
+  }
+  if (leftover) {
+    yield leftover;
+  }
+  closeSync(fd);
+}

--- a/src/vscode.ts
+++ b/src/vscode.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { vscodeStoragePaths, vscodeInsidersStoragePaths } from "./paths.js";
 import type { SourceFinding, SourceKind, UsageRecord } from "./types.js";
 import type { SourceParseResult } from "./source.js";
-import { roughTokens, DISPLAY_NAMES } from "./utils.js";
+import { roughTokens, DISPLAY_NAMES, readLinesFromFile } from "./utils.js";
 
 export function defaultVsCodeWorkspaceStoragePaths(): string[] {
   return vscodeStoragePaths();
@@ -50,7 +50,7 @@ function setPath(
 
 function reconstructSession(file: string): any {
   const state: any = Object.create(null);
-  for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+  for (const line of readLinesFromFile(file)) {
     if (!line.trim()) continue;
     let event: any;
     try {
@@ -92,7 +92,7 @@ function collectSessionRequests(file: string): {
     }
   };
 
-  for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+  for (const line of readLinesFromFile(file)) {
     if (!line.trim()) continue;
     let event: any;
     try {


### PR DESCRIPTION
I run into an issue when the logs of copilot cli were greater than the node's string size limit of 512Mb (I guess I'm cooked after all).

Did a quick change to use streaming to fetch the lines of the log instead of loading them as a whole chunk.

>**Note:** Testes on node v24.13.0
 