### PR TITLE
fix(auto-model): preserve original model when remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm run generate -- --html report.html
 npm run generate -- --json
 ```
 
-> **Note on `auto` model:** Some tools (e.g. VS Code Copilot) may report the model as `auto` when the user has not selected a specific model. Credits for those requests will show as zero unless you specify `--auto-model` to map them to a known priced model. The HTML report will include a note indicating the remapping when this flag is used.
+> **Note on `auto` model:** Some tools (e.g. VS Code Copilot) may report the model as `auto` when the user has not selected a specific model. Credits for those requests will show as zero unless you specify `--auto-model` to map them to a known priced model. The HTML report will include a note when any `auto` records are remapped.
 
 ## How data is extracted
 

--- a/src/__tests__/html.test.ts
+++ b/src/__tests__/html.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { bucketTrend } from "../html.js";
+import { bucketTrend, renderHtml } from "../html.js";
+import { buildSummary, costRecords } from "../report.js";
 import type { CostedUsageRecord } from "../types.js";
 
 function rec(
@@ -31,6 +32,65 @@ function midnightLocal(dateStr: string): number {
 // ---------------------------------------------------------------------------
 // bucketTrend — empty / single
 // ---------------------------------------------------------------------------
+
+describe("renderHtml", () => {
+  it("shows escaped auto-model note only when remapping was applied", () => {
+    const records = costRecords(
+      [
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "auto",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      ],
+      { autoModel: "<gpt-5.3-codex>" }
+    );
+    const summary = buildSummary({
+      autoModel: "<gpt-5.3-codex>",
+      findings: [],
+      records,
+      toolFindings: [],
+    });
+
+    const html = renderHtml(summary);
+
+    expect(html).toContain("Auto model remapped");
+    expect(html).toContain("1 records reported as");
+    expect(html).toContain("&lt;gpt-5.3-codex&gt;");
+    expect(html).not.toContain("<gpt-5.3-codex>");
+  });
+
+  it("does not show auto-model note when no auto records were remapped", () => {
+    const records = costRecords(
+      [
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "gpt-5-mini",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      ],
+      { autoModel: "gpt-5.3-codex" }
+    );
+    const summary = buildSummary({
+      autoModel: "gpt-5.3-codex",
+      findings: [],
+      records,
+      toolFindings: [],
+    });
+
+    expect(renderHtml(summary)).not.toContain("Auto model remapped");
+  });
+});
 
 describe("bucketTrend", () => {
   it("returns empty array for no records", () => {

--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -453,6 +453,45 @@ describe("buildSummary", () => {
     ).toBe(true);
   });
 
+  it("counts auto-model remaps only when records were actually remapped", () => {
+    const records = costRecords(
+      [
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "auto",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "gpt-5-mini",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      ],
+      { autoModel: "gpt-5.3-codex" }
+    );
+
+    const summary = buildSummary({
+      autoModel: "gpt-5.3-codex",
+      findings: [],
+      records,
+      toolFindings: [],
+    });
+
+    expect(summary.autoModelAppliedCount).toBe(1);
+    expect(summary.byModel["gpt-5.3-codex"]!.calls).toBe(1);
+    expect(summary.byModel["gpt-5-mini"]!.calls).toBe(1);
+  });
+
   it("counts unique sessions", () => {
     const records = costRecords([
       {
@@ -523,6 +562,51 @@ describe("costRecords", () => {
     ]);
     expect(results).toHaveLength(1);
     expect(results[0]!.pricingKnown).toBe(true);
+    expect(results[0]!.pricingModel).toBe("gpt-5-mini");
+    expect(results[0]!.usd).toBeCloseTo(0.25, 6);
+  });
+
+  it("prices auto records with --auto-model while preserving original model", () => {
+    const results = costRecords(
+      [
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "auto",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      ],
+      { autoModel: " gpt-5.3-codex " }
+    );
+
+    expect(results[0]!.model).toBe("auto");
+    expect(results[0]!.pricingModel).toBe("gpt-5.3-codex");
+    expect(results[0]!.pricingKnown).toBe(true);
+    expect(results[0]!.usd).toBeCloseTo(1.75, 6);
+  });
+
+  it("does not remap non-auto records", () => {
+    const results = costRecords(
+      [
+        {
+          source: "vscode",
+          sourcePath: "/mock",
+          provider: "github-copilot",
+          model: "gpt-5-mini",
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      ],
+      { autoModel: "gpt-5.3-codex" }
+    );
+
+    expect(results[0]!.model).toBe("gpt-5-mini");
     expect(results[0]!.pricingModel).toBe("gpt-5-mini");
     expect(results[0]!.usd).toBeCloseTo(0.25, 6);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ const options = program.opts<{
 
 let periodDays: number | undefined;
 let sinceMs: number | undefined;
+const autoModel = options.autoModel?.trim() || undefined;
 
 if (options.since && options.days) {
   console.error(
@@ -100,13 +101,13 @@ for (const adapter of Object.values(sourceAdapters)) {
 dbg("all sources parsed", t0);
 
 const tCost = Date.now();
-const costed = costRecords(records, { autoModel: options.autoModel });
+const costed = costRecords(records, { autoModel });
 dbg("costRecords", tCost);
 
 const tSummary = Date.now();
 const summary = buildSummary({
   periodDays,
-  autoModel: options.autoModel,
+  autoModel,
   findings,
   records: costed,
   toolFindings,

--- a/src/html.ts
+++ b/src/html.ts
@@ -279,8 +279,9 @@ function renderWarnings(summary: Summary): string {
 }
 
 function renderAutoModelNote(summary: Summary): string {
-  if (!summary.autoModel) return "";
-  return `<section class="warning-banner"><span class="warn-icon" aria-hidden="true">ℹ️</span><div class="warn-content"><p class="warn-title">Auto model remapped</p><p class="warn-item">Records reported as <strong>auto</strong> have been counted as <strong>${escapeHtml(summary.autoModel)}</strong> for cost estimation.</p></div></section>`;
+  if (!summary.autoModel || !summary.autoModelAppliedCount) return "";
+  const count = summary.autoModelAppliedCount.toLocaleString();
+  return `<section class="warning-banner"><span class="warn-icon" aria-hidden="true">ℹ️</span><div class="warn-content"><p class="warn-title">Auto model remapped</p><p class="warn-item">${count} records reported as <strong>auto</strong> have been counted as <strong>${escapeHtml(summary.autoModel)}</strong> for cost estimation.</p></div></section>`;
 }
 
 export function renderHtml(summary: Summary): string {

--- a/src/report.ts
+++ b/src/report.ts
@@ -4,7 +4,7 @@ import type {
   Summary,
   ToolFinding,
 } from "./types.js";
-import { comparePlans, costRecord } from "./pricing.js";
+import { comparePlans, costRecord, normalizeModel } from "./pricing.js";
 import { renderTable } from "./table.js";
 import { DISPLAY_NAMES } from "./utils.js";
 
@@ -53,6 +53,15 @@ export function buildSummary(args: {
   totals.sessions = sessions.size;
   totals.userPromptParents = parents.size;
 
+  const autoModel = args.autoModel?.trim();
+  const autoModelAppliedCount = autoModel
+    ? args.records.filter(
+        (record) =>
+          normalizeModel(record.model) === "auto" &&
+          record.pricingModel !== "auto"
+      ).length
+    : 0;
+
   const byModel: Summary["byModel"] = {};
   for (const record of args.records) {
     const key = record.pricingModel ?? record.model;
@@ -73,7 +82,8 @@ export function buildSummary(args: {
   return {
     generatedAt: new Date().toISOString(),
     periodDays: args.periodDays,
-    autoModel: args.autoModel,
+    autoModel,
+    autoModelAppliedCount,
     sources: args.findings,
     records: args.records,
     toolFindings: args.toolFindings,
@@ -87,10 +97,11 @@ export function costRecords(
   records: Parameters<typeof costRecord>[0][],
   options?: { autoModel?: string }
 ): CostedUsageRecord[] {
-  const autoModel = options?.autoModel;
+  const autoModel = options?.autoModel?.trim();
   return records.map((record) => {
-    if (autoModel && record.model.toLowerCase().trim() === "auto") {
-      return costRecord({ ...record, model: autoModel });
+    if (autoModel && normalizeModel(record.model) === "auto") {
+      const costed = costRecord({ ...record, model: autoModel });
+      return { ...costed, model: record.model };
     }
     return costRecord(record);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface Summary {
   generatedAt: string;
   periodDays?: number;
   autoModel?: string;
+  autoModelAppliedCount?: number;
   sources: SourceFinding[];
   records: CostedUsageRecord[];
   toolFindings: ToolFinding[];


### PR DESCRIPTION
## What changed

- Preserve original `auto` model values in detailed output while using `pricingModel` for forced cost estimation.
- Trim `--auto-model` input before applying it.
- Track `autoModelAppliedCount` and only show the HTML remap note when records were actually remapped.
- Update README wording for the conditional HTML note.
- Add tests covering auto remapping, non-auto behavior, applied counts, and HTML escaping/visibility.

## Context

PR #40 added `--auto-model`. This follow-up keeps reports auditable and avoids showing a remap note when no `auto` records exist.

## Test plan

- [x] npm run build
- [x] npm test