### PR TITLE
fix(pricing): update Goldeneye rate

### DIFF
--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -126,6 +126,23 @@ describe("model aliases", () => {
     expect(result.pricingKnown).toBe(true);
   });
 
+  it("prices Goldeneye with its direct published rate", () => {
+    const record: UsageRecord = {
+      source: "opencode",
+      sourcePath: "/mock",
+      provider: "github-copilot",
+      model: "goldeneye",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    const result = costRecord(record);
+    expect(result.pricingModel).toBe("goldeneye");
+    expect(result.pricingKnown).toBe(true);
+    expect(result.usd).toBeCloseTo(11.25, 6);
+  });
+
   it("still returns unknown for truly unknown models", () => {
     const record: UsageRecord = {
       source: "opencode",

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -64,7 +64,7 @@ export const MODEL_PRICES: Record<string, PriceRate> = {
   "gemini-2.5-pro": { input: 1.25, cachedInput: 0.125, output: 10.0 },
   "gemini-3-flash": { input: 0.5, cachedInput: 0.05, output: 3.0 },
   "gemini-3.1-pro": { input: 2.0, cachedInput: 0.2, output: 12.0 },
-  goldeneye: { input: 1.75, cachedInput: 0.175, output: 14.0 },
+  goldeneye: { input: 1.25, cachedInput: 0.125, output: 10.0 },
 };
 
 // Map older/unlisted models to the closest priced equivalent.
@@ -79,7 +79,6 @@ export const MODEL_ALIASES: Record<string, string> = {
   "gemini-3-flash-preview": "gemini-3-flash",
   "gemini-3-pro-preview": "gemini-3.1-pro",
   "gemini-3.1-pro-preview": "gemini-3.1-pro",
-  goldeneye: "gpt-5.2-codex",
 };
 
 export const PLANS: Record<string, number> = {


### PR DESCRIPTION
## What changed

- Update Goldeneye pricing to its direct published Copilot rate.
- Remove stale Goldeneye alias to GPT-5.2-Codex pricing.
- Add coverage proving Goldeneye uses the direct rate.

## Context

GitHub's current Copilot pricing table lists Goldeneye at $1.25 input, $0.125 cached input, and $10 output per 1M tokens. The previous local rate overestimated Goldeneye usage.

## Test plan

- [x] npm run build
- [x] npm test
