### PR TITLE
feat(cli): add terminal report flag

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -95,7 +95,51 @@ describe("CLI — end-to-end fixture parsing", () => {
   });
 });
 
-describe("CLI — --since and --days mutual exclusion", () => {
+describe("CLI — terminal report", () => {
+  it("prints a compact report without writing HTML/PNG", () => {
+    const home = makeTempHome();
+    writeCopilotCliEvents(home, "s1", [
+      {
+        type: "session.start",
+        data: { sessionId: "s1" },
+        id: "start",
+        timestamp: "2026-05-01T00:00:00.000Z",
+      },
+      {
+        type: "session.shutdown",
+        id: "shutdown",
+        timestamp: "2026-05-01T00:00:02.000Z",
+        data: {
+          modelMetrics: {
+            "gpt-5-mini": {
+              requests: { count: 1, cost: 1 },
+              usage: {
+                inputTokens: 1_000_000,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    const result = spawnSync(tsx, [cliPath, "--terminal"], {
+      encoding: "utf8",
+      timeout: 15_000,
+      env: { ...process.env, HOME: home },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("copilot-arewecooked");
+    expect(result.stdout).toContain("Estimated cost: 25 AI credits");
+    expect(result.stdout).not.toContain("HTML report written");
+    expect(result.stdout).not.toContain("PNG screenshot written");
+  });
+});
+
+describe("CLI — mutual exclusion", () => {
   it("exits with code 1 when both --since and --days are provided", () => {
     const result = spawnSync(
       tsx,
@@ -112,5 +156,31 @@ describe("CLI — --since and --days mutual exclusion", () => {
       { encoding: "utf8", timeout: 15_000 }
     );
     expect(result.stderr).toContain("mutually exclusive");
+  });
+
+  it("exits with code 1 when --json and --terminal are provided", () => {
+    const result = spawnSync(tsx, [cliPath, "--json", "--terminal"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--json and --terminal are mutually exclusive"
+    );
+  });
+
+  it("exits with code 1 when --html and --terminal are provided", () => {
+    const result = spawnSync(
+      tsx,
+      [cliPath, "--html", "report.html", "--terminal"],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+      }
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--html and --terminal are mutually exclusive"
+    );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer";
-import { buildSummary, costRecords } from "./report.js";
+import { buildSummary, costRecords, renderConsole } from "./report.js";
 import { sourceAdapters } from "./sources.js";
 import { renderHtml } from "./html.js";
 
@@ -32,6 +32,7 @@ program
     "only include records from this date onward (YYYY-MM-DD)"
   )
   .option("--json", "print detailed normalized JSON instead of HTML")
+  .option("--terminal", "print a compact terminal report instead of HTML/PNG")
   .option(
     "--html [path]",
     "write HTML report path (default: copilot-report-YYYY-MM-DD-<hex>.html)"
@@ -46,6 +47,7 @@ const options = program.opts<{
   days?: string;
   since?: string;
   json?: boolean;
+  terminal?: boolean;
   html?: boolean | string;
   autoModel?: string;
 }>();
@@ -57,6 +59,20 @@ const autoModel = options.autoModel?.trim() || undefined;
 if (options.since && options.days) {
   console.error(
     "--since and --days are mutually exclusive; use one or the other"
+  );
+  process.exit(1);
+}
+
+if (options.json && options.terminal) {
+  console.error(
+    "--json and --terminal are mutually exclusive; use one or the other"
+  );
+  process.exit(1);
+}
+
+if (options.html && options.terminal) {
+  console.error(
+    "--html and --terminal are mutually exclusive; use one or the other"
   );
   process.exit(1);
 }
@@ -116,6 +132,8 @@ dbg("buildSummary", tSummary);
 
 if (options.json) {
   console.log(JSON.stringify(summary, null, 2));
+} else if (options.terminal) {
+  console.log(renderConsole(summary));
 } else {
   const today = new Date().toISOString().slice(0, 10);
   const hexId = randomBytes(3).toString("hex");


### PR DESCRIPTION
## What changed

- Add `--terminal` to print the compact report directly in stdout.
- Skip HTML and PNG report generation when terminal mode is selected.
- Add mutual-exclusion errors for `--terminal` with `--json` or `--html`.
- Cover terminal output and conflicts in CLI tests.

## Context

Some users want a quick terminal-only summary, especially when running through `npx`, without creating local report files or launching Puppeteer for screenshots.

<img width="318" height="375" alt="image" src="https://github.com/user-attachments/assets/5c36fa6b-b760-49f6-9409-f3275e03f108" />


## Test plan

- [x] npm run build
- [x] npm test
