### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -95,7 +95,51 @@ describe("CLI — end-to-end fixture parsing", () => {
   });
 });
 
-describe("CLI — --since and --days mutual exclusion", () => {
+describe("CLI — terminal report", () => {
+  it("prints a compact report without writing HTML/PNG", () => {
+    const home = makeTempHome();
+    writeCopilotCliEvents(home, "s1", [
+      {
+        type: "session.start",
+        data: { sessionId: "s1" },
+        id: "start",
+        timestamp: "2026-05-01T00:00:00.000Z",
+      },
+      {
+        type: "session.shutdown",
+        id: "shutdown",
+        timestamp: "2026-05-01T00:00:02.000Z",
+        data: {
+          modelMetrics: {
+            "gpt-5-mini": {
+              requests: { count: 1, cost: 1 },
+              usage: {
+                inputTokens: 1_000_000,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    const result = spawnSync(tsx, [cliPath, "--terminal"], {
+      encoding: "utf8",
+      timeout: 15_000,
+      env: { ...process.env, HOME: home },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("copilot-arewecooked");
+    expect(result.stdout).toContain("Estimated cost: 25 AI credits");
+    expect(result.stdout).not.toContain("HTML report written");
+    expect(result.stdout).not.toContain("PNG screenshot written");
+  });
+});
+
+describe("CLI — mutual exclusion", () => {
   it("exits with code 1 when both --since and --days are provided", () => {
     const result = spawnSync(
       tsx,
@@ -112,5 +156,31 @@ describe("CLI — --since and --days mutual exclusion", () => {
       { encoding: "utf8", timeout: 15_000 }
     );
     expect(result.stderr).toContain("mutually exclusive");
+  });
+
+  it("exits with code 1 when --json and --terminal are provided", () => {
+    const result = spawnSync(tsx, [cliPath, "--json", "--terminal"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--json and --terminal are mutually exclusive"
+    );
+  });
+
+  it("exits with code 1 when --html and --terminal are provided", () => {
+    const result = spawnSync(
+      tsx,
+      [cliPath, "--html", "report.html", "--terminal"],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+      }
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--html and --terminal are mutually exclusive"
+    );
   });
 });

--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -126,6 +126,23 @@ describe("model aliases", () => {
     expect(result.pricingKnown).toBe(true);
   });
 
+  it("prices Goldeneye with its direct published rate", () => {
+    const record: UsageRecord = {
+      source: "opencode",
+      sourcePath: "/mock",
+      provider: "github-copilot",
+      model: "goldeneye",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    const result = costRecord(record);
+    expect(result.pricingModel).toBe("goldeneye");
+    expect(result.pricingKnown).toBe(true);
+    expect(result.usd).toBeCloseTo(11.25, 6);
+  });
+
   it("still returns unknown for truly unknown models", () => {
     const record: UsageRecord = {
       source: "opencode",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer";
-import { buildSummary, costRecords } from "./report.js";
+import { buildSummary, costRecords, renderConsole } from "./report.js";
 import { sourceAdapters } from "./sources.js";
 import { renderHtml } from "./html.js";
 
@@ -32,6 +32,7 @@ program
     "only include records from this date onward (YYYY-MM-DD)"
   )
   .option("--json", "print detailed normalized JSON instead of HTML")
+  .option("--terminal", "print a compact terminal report instead of HTML/PNG")
   .option(
     "--html [path]",
     "write HTML report path (default: copilot-report-YYYY-MM-DD-<hex>.html)"
@@ -46,6 +47,7 @@ const options = program.opts<{
   days?: string;
   since?: string;
   json?: boolean;
+  terminal?: boolean;
   html?: boolean | string;
   autoModel?: string;
 }>();
@@ -57,6 +59,20 @@ const autoModel = options.autoModel?.trim() || undefined;
 if (options.since && options.days) {
   console.error(
     "--since and --days are mutually exclusive; use one or the other"
+  );
+  process.exit(1);
+}
+
+if (options.json && options.terminal) {
+  console.error(
+    "--json and --terminal are mutually exclusive; use one or the other"
+  );
+  process.exit(1);
+}
+
+if (options.html && options.terminal) {
+  console.error(
+    "--html and --terminal are mutually exclusive; use one or the other"
   );
   process.exit(1);
 }
@@ -116,6 +132,8 @@ dbg("buildSummary", tSummary);
 
 if (options.json) {
   console.log(JSON.stringify(summary, null, 2));
+} else if (options.terminal) {
+  console.log(renderConsole(summary));
 } else {
   const today = new Date().toISOString().slice(0, 10);
   const hexId = randomBytes(3).toString("hex");

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -64,7 +64,7 @@ export const MODEL_PRICES: Record<string, PriceRate> = {
   "gemini-2.5-pro": { input: 1.25, cachedInput: 0.125, output: 10.0 },
   "gemini-3-flash": { input: 0.5, cachedInput: 0.05, output: 3.0 },
   "gemini-3.1-pro": { input: 2.0, cachedInput: 0.2, output: 12.0 },
-  goldeneye: { input: 1.75, cachedInput: 0.175, output: 14.0 },
+  goldeneye: { input: 1.25, cachedInput: 0.125, output: 10.0 },
 };
 
 // Map older/unlisted models to the closest priced equivalent.
@@ -79,7 +79,6 @@ export const MODEL_ALIASES: Record<string, string> = {
   "gemini-3-flash-preview": "gemini-3-flash",
   "gemini-3-pro-preview": "gemini-3.1-pro",
   "gemini-3.1-pro-preview": "gemini-3.1-pro",
-  goldeneye: "gpt-5.2-codex",
 };
 
 export const PLANS: Record<string, number> = {


### PR DESCRIPTION
## What changed

- Add `--terminal` for a compact stdout report without generating HTML/PNG files.
- Update Goldeneye pricing to GitHub's current published Copilot rate.
- Remove the stale Goldeneye alias to GPT-5.2-Codex pricing.
- Add CLI and pricing test coverage for the new behavior.

## Context

This ships the terminal report option for `npx copilot-arewecooked --terminal` and corrects Goldeneye cost estimates before the next npm release.

## Test plan

- [x] npm run build
- [x] npm test
