### PR TITLE
fix(release): dispatch publish after release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,13 +8,29 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+  dispatch-publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch publish workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh workflow run publish.yml --ref main -f tag="$TAG"


### PR DESCRIPTION
## What changed

- Capture release-please outputs for whether a release was created and which tag was created.
- Add a follow-up job that automatically dispatches `publish.yml` with that tag.
- Grant `actions: write` to the release workflow so it can trigger the publish workflow.

## Context

Tags created by release-please with `GITHUB_TOKEN` do not reliably trigger a separate `on: push: tags` workflow. Dispatching `publish.yml` keeps npm trusted publishing in the existing workflow file while removing the manual “Run workflow and type tag” step.

## Test plan

- [x] npm run build
- [x] npm test
