### PR TITLE
fix(release): set repo for publish dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,5 +32,6 @@ jobs:
       - name: Dispatch publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh workflow run publish.yml --ref main -f tag="$TAG"


### PR DESCRIPTION
## What changed

- Set `GH_REPO` when dispatching `publish.yml` from `release-please.yml`.

## Context

The dispatch job has no checkout, so `gh workflow run` could not infer the repository and failed with `fatal: not a git repository`. Passing `github.repository` lets the CLI dispatch the publish workflow without checking out source.

## Test plan

- [x] npm run build
- [x] npm test
