### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -138,7 +138,7 @@ describe("model aliases", () => {
       cacheWriteTokens: 0,
     };
     const result = costRecord(record);
-    expect(result.pricingModel).toBe("raptor-mini");
+    expect(result.pricingModel).toBe("gpt-5-mini");
     expect(result.pricingKnown).toBe(true);
   });
 

--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -126,6 +126,22 @@ describe("model aliases", () => {
     expect(result.pricingKnown).toBe(true);
   });
 
+  it("prices OSWE VS Code Prime as Raptor mini", () => {
+    const record: UsageRecord = {
+      source: "vscode",
+      sourcePath: "/mock",
+      provider: "github-copilot",
+      model: "oswe-vscode-prime",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    const result = costRecord(record);
+    expect(result.pricingModel).toBe("raptor-mini");
+    expect(result.pricingKnown).toBe(true);
+  });
+
   it("prices Goldeneye with its direct published rate", () => {
     const record: UsageRecord = {
       source: "opencode",

--- a/src/__tests__/pricing.test.ts
+++ b/src/__tests__/pricing.test.ts
@@ -138,7 +138,7 @@ describe("model aliases", () => {
       cacheWriteTokens: 0,
     };
     const result = costRecord(record);
-    expect(result.pricingModel).toBe("gpt-5-mini");
+    expect(result.pricingModel).toBe("raptor-mini");
     expect(result.pricingKnown).toBe(true);
   });
 

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -75,6 +75,7 @@ export const MODEL_ALIASES: Record<string, string> = {
   "gpt-5.1-codex-max": "gpt-5.2-codex",
   "gpt-4o": "gpt-4.1",
   "gpt-4o-mini": "gpt-5-mini",
+  "oswe-vscode-prime": "gpt-5-mini", // "Raptor mini (Preview)"
   "gemini-3-pro": "gemini-3.1-pro",
   "gemini-3-flash-preview": "gemini-3-flash",
   "gemini-3-pro-preview": "gemini-3.1-pro",

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -75,7 +75,7 @@ export const MODEL_ALIASES: Record<string, string> = {
   "gpt-5.1-codex-max": "gpt-5.2-codex",
   "gpt-4o": "gpt-4.1",
   "gpt-4o-mini": "gpt-5-mini",
-  "oswe-vscode-prime": "gpt-5-mini", // "Raptor mini (Preview)"
+  "oswe-vscode-prime": "raptor-mini",
   "gemini-3-pro": "gemini-3.1-pro",
   "gemini-3-flash-preview": "gemini-3-flash",
   "gemini-3-pro-preview": "gemini-3.1-pro",


### PR DESCRIPTION
## What changed

- Adds pricing support for the `oswe-vscode-prime` model seen in VS Code logs.
- Maps OSWE VS Code Prime to `raptor-mini`, matching GitHub's Raptor mini pricing.
- Adds regression coverage for the model alias.

## Context

This releases the fix for unknown `oswe-vscode-prime` records showing zero cost, closing the pricing gap reported by users.

## Test plan

- [x] `npm test`