### PR TITLE
ci: add CI workflow for build and test on Node 20, 22, 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## What changed

- Add `.github/workflows/ci.yml` with build + typecheck + test matrix

## Context

No CI exists today. The publish workflow runs tests, but only on release. This adds a proper CI gate on pushes to develop and PRs to develop/main, testing against Node 20, 22, and 24.

## Test plan

- [ ] CI runs on this PR and passes (at least the non-SQLite tests)